### PR TITLE
fix: strip undefined values before Firestore sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,11 +56,12 @@ async function initFirestoreSync() {
       async syncToCloud(table, data) {
         try {
           const docId = `${data.project || 'global'}_${data.id || Date.now()}`;
-          await firestore.collection(`${collectionPrefix}_${table}`).doc(docId).set({
-            ...data,
-            syncedAt: new Date().toISOString(),
-            machine: config.machineId || "unknown",
-          }, { merge: true });
+          // Strip undefined values — Firestore rejects them
+          const clean = Object.fromEntries(
+            Object.entries({ ...data, syncedAt: new Date().toISOString(), machine: config.machineId || "unknown" })
+              .filter(([, v]) => v !== undefined)
+          );
+          await firestore.collection(`${collectionPrefix}_${table}`).doc(docId).set(clean, { merge: true });
         } catch (e) {
           console.error(`Firestore sync error (${table}):`, e.message);
         }


### PR DESCRIPTION
## Summary

- Firestore rejects `undefined` values in documents
- Optional fields (category, rationale, context, notes) are `undefined` when not provided
- Fix: filter out undefined entries before calling Firestore `set()`

## Test plan

- [x] Verified: `remember_decision` without category no longer causes Firestore sync error
- [x] Verified: `remember_error` without context no longer causes Firestore sync error
- [x] Verified: `save_session` without notes no longer causes Firestore sync error

🤖 Generated with [Claude Code](https://claude.com/claude-code)