### PR TITLE
chore: migrate from ARC to GitHub-hosted runners

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   auto-merge:
     name: Auto-merge PR
-    runs-on: arc-linux-claude-memory-mcp
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-resolve-copilot-conversations.yml
+++ b/.github/workflows/auto-resolve-copilot-conversations.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   auto-resolve-copilot-conversations:
     name: Auto-resolve Copilot Conversations
-    runs-on: arc-linux-claude-memory-mcp
+    runs-on: ubuntu-latest
     if: |
       (github.event_name == 'pull_request_review' && contains(github.event.review.user.login, 'copilot')) ||
       (github.event_name == 'check_suite' && github.event.check_suite.conclusion == 'success')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check:
     name: Validate
-    runs-on: arc-linux-claude-memory-mcp
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: arc-linux-claude-memory-mcp
+    runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
         with:

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   request-review:
     name: Request Review-E
-    runs-on: arc-linux-claude-memory-mcp
+    runs-on: ubuntu-latest
     if: >-
       github.event.action != 'closed' &&
       !github.event.pull_request.draft &&
@@ -86,7 +86,7 @@ jobs:
 
   notify-closed:
     name: Notify PR Closed/Merged
-    runs-on: arc-linux-claude-memory-mcp
+    runs-on: ubuntu-latest
     if: >-
       github.event.action == 'closed'
     permissions:


### PR DESCRIPTION
Replace self-hosted ARC runner labels with `ubuntu-latest`. ARC runners shut down — using GitHub-hosted runners (3000 min/month included).